### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ Use the attribute elevation on Material Button to get the full Material Desing (
         android:elevation="2dp"
      />
 
-###TODO
+### TODO
 
 Upload to maven central... 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
